### PR TITLE
feat: Improve COmanage account linking and error handling

### DIFF
--- a/plugins/microservices/comanage_account_linking.yaml.template
+++ b/plugins/microservices/comanage_account_linking.yaml.template
@@ -2,7 +2,6 @@ module: comanage_account_linking.COmanageAccountLinkingMicroService
 name: COmanageAccountLinking
 config:
   api_url:
-  redirect_url:
   api_user:
   password:
   target_backends:


### PR DESCRIPTION
This commit enhances the COmanage account linking microservice with improved error handling and data management.

Key changes:

-   Refactored exception handling: Replaced `Exception` with more specific exceptions like `COmanageAPIError` and `COmanageUserNotActiveError` for better error categorization.
-   Added user status check: Checks if the user is active in COmanage before proceeding.
-   Improved data flow: Added `co_manage_user` field to `UserAttributes` to store COmanage user data and ensure data is passed through the authentication flow.
-   Added logging: Added more logging for debugging and monitoring.
-   Fixed a bug where the service would redirect to the register page if the user was not found in COmanage.
-   Added a mock data class to improve the testability of the service.