### PR TITLE
feat: Add CILogon OpenID Connect backend

### DIFF
--- a/plugins/backends/cilogon.py
+++ b/plugins/backends/cilogon.py
@@ -1,0 +1,42 @@
+import logging
+from satosa.backends.openid_connect import OpenIDConnectBackend
+
+logger = logging.getLogger(__name__)
+
+
+class OpenIDConnectCustomBackend(OpenIDConnectBackend):
+    """
+    A custom OpenID Connect backend that extends the base OpenIDConnectBackend with specific token retrieval logic.
+    
+    This backend handles token retrieval for OpenID Connect authentication, with support for custom response type skew
+    and detailed token request processing.
+    """
+
+    def _get_tokens(self, authn_response, context):
+        """
+        :param authn_response: authentication response from OP
+        :type authn_response: oic.oic.message.AuthorizationResponse
+        :return: access token and ID Token claims
+        :rtype: Tuple[Optional[str], Optional[Mapping[str, str]]]
+        """
+
+        skew = self.config.get("auth_req_params", {}).get("response_type", 0)
+
+        logger.debug('-> AUTHN RESPONSE: %s', authn_response)
+        logger.debug('-> Custom skew: %s', skew)
+
+        if "code" in authn_response:
+            # make token request
+            args = {
+                "code": authn_response["code"],
+                "redirect_uri": self.client.registration_response['redirect_uris'][0],
+            }
+
+            token_resp = self.client.do_access_token_request(scope="openid", state=authn_response["state"],
+                                                             request_args=args,
+                                                             authn_method=self.client.registration_response[
+                                                                 "token_endpoint_auth_method"],
+                                                             skew=skew)
+
+            self._check_error_response(token_resp, context)
+            return token_resp["access_token"], token_resp["id_token"]

--- a/plugins/backends/cilogon.yaml.template
+++ b/plugins/backends/cilogon.yaml.template
@@ -1,0 +1,42 @@
+module: cilogon.OpenIDConnectCustomBackend
+name: cilogon
+config:
+  provider_metadata:
+    issuer: https://cilogon.org
+  client:
+    verify_ssl: yes
+    auth_req_params:
+      response_type: code
+      scope: [openid, email, profile, org.cilogon.userinfo]
+      skew: 10
+    client_metadata:
+      application_name: 
+      application_type: web
+      contacts: []
+      client_id: 
+      client_secret: 
+      redirect_uris: [<base_url>/<name>]
+      subject_type: public
+  entity_info:
+    contact_person:
+      - contact_type: "technical"
+        email_address: []
+        given_name: ""
+        sur_name: ""
+      - contact_type: "support"
+        email_address: []
+        given_name: ""
+    organization:
+        display_name:
+        - ["", "en"]
+        name:
+        - ["", "se"]
+        - ["", "en"]
+        url:
+        - ["", "en"]
+        - ["", "se"]
+    ui_info:
+        description:
+        - ["", "en"]
+        display_name:
+        - ["", "en"] 


### PR DESCRIPTION
This commit introduces a new backend for authenticating users via the CILogon OpenID Connect provider. It includes:

-   A new Python file (`cilogon.py`) that defines a custom OpenID Connect backend, extending the base class to handle specific token retrieval logic, including custom response type skew.
-   A new YAML template file (`cilogon.yaml.template`) to configure the CILogon backend, including provider metadata, client details, and entity information.